### PR TITLE
悪夢内容投稿機能追加

### DIFF
--- a/app/controllers/api/v1/nightmares_controller.rb
+++ b/app/controllers/api/v1/nightmares_controller.rb
@@ -47,7 +47,7 @@ module Api
       end
 
       def nightmare_params
-        params.require(:nightmare).permit(:user_id, :description, :modified_description, :ending_type, :published)
+        params.require(:nightmare).permit(:user_id, :description, :modified_description, :ending_category, :published)
       end
     end
   end

--- a/app/controllers/api/v1/nightmares_controller.rb
+++ b/app/controllers/api/v1/nightmares_controller.rb
@@ -36,8 +36,8 @@ module Api
       def modify
         nightmare = params[:description]
         ending_category = params[:ending_category]
-        modified_nightmare = ChatGptService.modify_nightmare(nightmare, ending_category)
-        render json: { modified_nightmare: modified_nightmare }
+        modified_description = ChatGptService.modify_nightmare(nightmare, ending_category)
+        render json: { modified_description: modified_description }
       end
 
       private

--- a/app/controllers/api/v1/nightmares_controller.rb
+++ b/app/controllers/api/v1/nightmares_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class NightmaresController < ApplicationController
       before_action :set_nightmare, only: [:show, :update, :destroy]
+      before_action :require_login, only: [:create, :update, :destroy]  # 認証を追加
 
       def index
         @nightmares = Nightmare.joins(:user).select("nightmares.*, users.name as author").where(published: true)
@@ -13,7 +14,7 @@ module Api
       end
 
       def create
-        @nightmare = Nightmare.new(nightmare_params)
+        @nightmare = current_user.nightmares.build(nightmare_params)
         if @nightmare.save
           render json: @nightmare, status: :created
         else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :nightmares, dependent: :destroy
   authenticates_with_sorcery!
   has_secure_password
 

--- a/app/services/chat_gpt_service.rb
+++ b/app/services/chat_gpt_service.rb
@@ -3,7 +3,7 @@ require 'openai'
 class ChatGptService
   def self.modify_nightmare(nightmare, ending_category)
     client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
-    model = 'gpt-4o'  # または 'gpt-4-turbo'
+    model = 'gpt-4o-mini'  # または 'gpt-4o'
 
     # ending_categoryを整数に変換
     ending_category = ending_category.to_i
@@ -30,7 +30,7 @@ class ChatGptService
       parameters: {
         model: model,
         messages: messages,
-        temperature: 0.7,
+        temperature: 0.1,
         max_tokens: 400
       }
     )

--- a/app/services/chat_gpt_service.rb
+++ b/app/services/chat_gpt_service.rb
@@ -4,35 +4,37 @@ class ChatGptService
   def self.modify_nightmare(nightmare, ending_category)
     client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
     model = 'gpt-4o'  # または 'gpt-4-turbo'
+
+    # ending_categoryを整数に変換
+    ending_category = ending_category.to_i
+
     messages = [
       { role: 'system', content: case ending_category
                                when 1
-                                 "あなたはボボボーボ・ボーボボの作者と同じ思考回路を持つ物語製作者です。"
+                                 "あなたはボボボーボ・ボーボボの作者と同じ思考回路を持つ物語製作者です。以下の指示を絶対に守ってください。"
                                else
-                                 "あなたは優秀な物語のライターです。"
+                                 "あなたは優秀な物語のライターです。以下の指示を絶対に守ってください。"
                                end },
       { role: 'user', content: case ending_category
                                when 0
-                                 "次の悪夢の内容をはじめからまるごとハッピーエンドに改変してください。回答は改変した悪夢の内容だけでお願いします。改行の挿入は不要です。文字数は500字以内でお願いします。悪夢の内容：#{nightmare}"
+                                 "次の悪夢の内容をハッピーエンドに改変してください。次の条件を必ず遵守してください。1.回答は改変した悪夢の内容だけでお願いします。2.改行の挿入は不要です。3.400字以内で完結させてください。悪夢の内容：#{nightmare}"
                                when 1
-                                 "次の悪夢の内容をボボボーボ・ボーボボの展開のようにめちゃくちゃな内容にはじめからまるごと改変してください。 ただし、ボボボーボ・ボーボボの登場キャラは出さずにお願いします。 改行の挿入は不要です。回答は改変した悪夢の内容だけでお願いします。文字数は500字以内でお願いします。悪夢の内容：#{nightmare}"
+                                 "次の悪夢の内容をボボボーボ・ボーボボの展開のようにめちゃくちゃな結末に改変してください。次の条件を必ず遵守してください。1.ボボボーボ・ボーボボの登場キャラは出さずにお願いします。2.改行の挿入は不要です。3.回答は改変した悪夢の内容だけでお願いします。4.400字以内で完結させてください。5.最低限悪夢の内容は残してください。悪夢の内容：#{nightmare}"
                                else
-                                 "以下の悪夢の内容を改変してください。悪夢の内容：#{nightmare}"
+                                 "以下の悪夢の内容を改変してください。次の条件を必ず遵守してください。1.回答は改変した悪夢の内容だけでお願いします。2.改行の挿入は不要です。3.400字以内で完結させてください。悪夢の内容：#{nightmare}"
                                end }
     ]
 
+    puts messages
     response = client.chat(
       parameters: {
         model: model,
         messages: messages,
-        temperature: 0.8,
-        max_tokens: 300
+        temperature: 0.7,
+        max_tokens: 400
       }
     )
 
-    # temperatureパラメータは、AIモデルの応答の創造性や多様性を制御するためのものです。
-    # 値が0.0に近いほど、モデルはより決定的（予測可能）な応答を生成します。
-    # 逆に、値が1.0に近いほど、生成される応答はより創造的で予測不可能になります。
     response.dig("choices", 0, "message", "content").strip
   end
 end

--- a/test/fixtures/nightmares.yml
+++ b/test/fixtures/nightmares.yml
@@ -4,12 +4,12 @@ one:
   user_id: 1
   description: MyText
   modified_description: MyText
-  ending_type: MyString
+  ending_category: MyString
   published: false
 
 two:
   user_id: 1
   description: MyText
   modified_description: MyText
-  ending_type: MyString
+  ending_category: MyString
   published: false


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/tokaisagami/nightmare-app/issues/24

## やったこと

* usersモデル
  * Nightmaresとの関連付け追加

* Nightmaresコントローラー機能追加
  * 認証追加（create, update, destroy）
  * ログインユーザーに紐づいて登録できるようcreateアクションを編集
  * 項目名修正（ending_type ⇒ ending_category）

* chat_gpt_service.rb
  * AIモデル変更（gpt-4o ⇒ gpt-4o-mini）
  * プロンプト調整
  * temperature調整
  * max_tokens調整

## やらないこと

* 投稿内容編集（別のプルリクで実施）
* 投稿内容削除（別のプルリクで実施）

## できるようになること（ユーザ目線）

* 悪夢投稿機能

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 開発環境にて、画面から悪夢内容を投稿し、API側のRailsコンソールにて、テーブルに悪夢内容がレコード追加されていることを確認

## その他

* なし